### PR TITLE
Refactor/parachute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ build: build-server
 build-server:
 	$(RUN_LISP) --eval '(asdf:make :riacl/server)'
 
+test-server:
+	$(RUN_LISP) --eval '(asdf:test-system :riacl/server)'
+
+test-client:
+	$(RUN_LISP) --eval '(asdf:test-system :riacl/client)'
+
 lint:
 	~/.roswell/bin/sblint | reviewdog -efm="%f:%l:%c: %m" -diff="git diff main"
 

--- a/riacl.asd
+++ b/riacl.asd
@@ -5,7 +5,7 @@
   :version "0.1.0"
   :author "David Krentzlin <david.krentzlin@gmail.com>"
   :source-control (:git "https://github.com/certainty/riacl.git")
-  :depends-on (#:riacl/server #:riacl/client))
+  :depends-on (#:riacl/server #:riacl/client #:riacl/server.tests))
 
 (defsystem "riacl/server"
   :description "A riak inspired distributed key-value store in Common Lisp."
@@ -85,11 +85,14 @@
 
 (defsystem "riacl/server.tests"
   :description "Unit tests for riacl/server"
-  :depends-on (#:lisp-unit2  #:riacl/server)
+  :depends-on (#:parachute #:riacl/server)
   :pathname "test/riacl.server"
   :components
   ((:file "package")
    (:file "runner")
+   (:module "config"
+    :components
+    ((:file "config")))
    (:module "cluster"
     :components
     ((:file "identifier")
@@ -114,7 +117,7 @@
 
 (defsystem "riacl/common.tests"
   :description "Unit tests for riacl/common"
-  :depends-on (#:lisp-unit2  #:riacl/common)
+  :depends-on (#:parachute  #:riacl/common)
   :pathname "test/riacl.common"
   :components
   ((:file "package")
@@ -137,7 +140,7 @@
 
 (defsystem "riacl/client.tests"
   :description "Unit tests for riacl/client"
-  :depends-on (#:lisp-unit2  #:riacl/client)
+  :depends-on (#:parachute  #:riacl/client)
   :pathname "test/riacl.client"
   :components
   ((:file "package")

--- a/test/riacl.client/package.lisp
+++ b/test/riacl.client/package.lisp
@@ -1,5 +1,5 @@
 (in-package :cl-user)
 
 (defpackage #:riacl.client.tests
-  (:use :cl :lisp-unit2)
+  (:use :cl :parachute)
   (:export #:run-suites))

--- a/test/riacl.common/network.lisp
+++ b/test/riacl.common/network.lisp
@@ -1,14 +1,14 @@
-(in-package #:riacl.common.tests.network)
+(in-package #:riacl.common.tests)
 
-(define-test address-happy-path ()
-  "Test the happy path of the parse-network-address function."
+(define-test address-happy-path
+    "Test the happy path of the parse-network-address function."
   (let ((address (network:parse-address "192.168.0.1:80")))
-    (assert-equal (network:address-ipv4 address) 3232235521)
-    (assert-equal (network:address-port address) 80)))
+    (is = 3232235521 (network:address-ipv4 address))
+    (is = 80 (network:address-port address) )))
 
-(define-test conversion-of-dotted-quad ()
-  "Test the conversion of a dotted quad to an integer."
-  (assert-equal
-   "168.1.1.1"
-   (network:integer->dotted-quad
-    (network:dotted-quad->integer "168.1.1.1"))))
+(define-test conversion-of-dotted-quad
+    "Test the conversion of a dotted quad to an integer."
+  (is string-equal
+      "168.1.1.1"
+      (network:integer->dotted-quad
+       (network:dotted-quad->integer "168.1.1.1"))))

--- a/test/riacl.common/package.lisp
+++ b/test/riacl.common/package.lisp
@@ -1,8 +1,6 @@
 (in-package :cl-user)
 
 (defpackage #:riacl.common.tests
-  (:use :cl :lisp-unit2)
+  (:use :cl :parachute)
   (:export #:run-suites))
 
-(defpackage #:riacl.common.tests.network
-  (:use :cl :lisp-unit2))

--- a/test/riacl.common/runner.lisp
+++ b/test/riacl.common/runner.lisp
@@ -1,18 +1,9 @@
 (in-package #:riacl.common.tests)
 
-(defmacro with-env-specific-setup (&body body)
-  (let ((db (gensym)))
-    `(if (uiop:getenvp "CI_ENV")
-         (let ((*debugger-hook*))
-           (let ((,db (with-summary () ,@body)))
-             (unless (and (null (lisp-unit2::failed-assertions ,db))
-                          (null (errors ,db)))
-               (uiop:quit 1))))
-         (with-summary () ,@body))))
-
 (defun run-suites ()
   (push :test *features*)
-  (with-env-specific-setup
-    (run-tests
-     :name "riacl.common.tests"
-     :package '(#:riacl.common.tests.network))))
+  (if (uiop:getenvp "CI_ENV")
+      (progn
+        (defvar cl-user::*exit-on-test-failures* t)
+        (parachute:test :riacl.common.tests :report 'plain))
+      (parachute:test :riacl.common.tests :report 'interactive)))

--- a/test/riacl.server/cluster/dvv.lisp
+++ b/test/riacl.server/cluster/dvv.lisp
@@ -61,7 +61,7 @@
     (true (dvv:descendsp c2 empty))))
 
 (define-test descendsp-self
-    :parent dvv-suite
+  :parent dvv-suite
   (let ((c1 (dvv:make-dotted-version-vector
              :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1))))
         (c2 (dvv:make-dotted-version-vector
@@ -70,7 +70,7 @@
     (true (dvv:descendsp c2 c2))))
 
 (define-test descendsp
-    :parent dvv-suite
+  :parent dvv-suite
   (let ((c1 (dvv:make-dotted-version-vector)))
     (dvv:incf-actor c1 +vnode-1+)
     (dvv:incf-actor c1 +vnode-3+)
@@ -80,7 +80,7 @@
       (true (dvv:descendsp c2 c1)))))
 
 (define-test merge-works
-    :parent dvv-suite
+  :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector
               :initial-history (list
                                 (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)
@@ -107,7 +107,7 @@
             history)))))
 
 (define-test merge-less-left
-    :parent dvv-suite
+  :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-dot (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)))
          (c2 (dvv:make-dotted-version-vector :initial-history
                                              (list (dvv:make-dot +vnode-2+ :counter 2 :timestamp 2))
@@ -121,7 +121,7 @@
         (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
 
 (define-test merge-less-right
-    :parent dvv-suite
+  :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-2+ :counter 2 :timestamp 2))
                                              :initial-dot (dvv:make-dot +vnode-3+ :counter 3 :timestamp 3)))
          (c2 (dvv:make-dotted-version-vector :initial-dot (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)))
@@ -134,7 +134,7 @@
         (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
 
 (define-test merge-same-id
-    :parent dvv-suite
+  :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 2))
                                              :initial-dot (dvv:make-dot +vnode-2+ :counter 1 :timestamp 4)))
          (c2 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 3))

--- a/test/riacl.server/cluster/dvv.lisp
+++ b/test/riacl.server/cluster/dvv.lisp
@@ -1,4 +1,6 @@
-(in-package :riacl.server.tests.cluster)
+(in-package :riacl.server.tests)
+
+(define-test dvv-suite)
 
 (defclass test-clock ()
   ((seconds
@@ -23,60 +25,62 @@
 (serapeum:defconst +vnode-4+ "urn:x-riacl:10:a:4")
 (serapeum:defconst +vnode-5+ "urn:x-riacl:10:a:5")
 
-(define-test dot-equality ()
-  "dot= works"
+(define-test dot-equality :parent dvv-suite
   (let ((a (dvv:make-dot +vnode-1+ :counter 1 :timestamp 2))
         (b (dvv:make-dot +vnode-1+ :counter 1 :timestamp 2))
         (c (dvv:make-dot +vnode-2+ :counter 1 :timestamp 2))
         (d (dvv:make-dot +vnode-1+ :counter 2 :timestamp 2))
         (e (dvv:make-dot +vnode-1+ :counter 1 :timestamp 3)))
-    (assert-true  (dvv:dot= a a) "Identical object")
-    (assert-true  (dvv:dot= a b) "Same values")
-    (assert-false (dvv:dot= a c) "Different actors => different dots")
-    (assert-false (dvv:dot= a d) "Different counter => different dots")
-    (assert-false (dvv:dot= a e) "Different timestamp => different dots")))
+    (true  (dvv:dot= a a) "Identical object")
+    (true  (dvv:dot= a b) "Same values")
+    (false (dvv:dot= a c) "Different actors => different dots")
+    (false (dvv:dot= a d) "Different counter => different dots")
+    (false (dvv:dot= a e) "Different timestamp => different dots")))
 
-(define-test incf-dot-works ()
+(define-test incf-dot-works :parent dvv-suite
   (with-test-clock (clock 10)
     (let ((subject (dvv:make-dot +vnode-1+ :counter 1 :timestamp 5)))
       (dvv:incf-dot subject)
-      (assert-equal 2 (dvv:dot-counter subject))
-      (assert-equal 10 (dvv:dot-timestamp subject))
+      (is = 2 (dvv:dot-counter subject))
+      (is = 10 (dvv:dot-timestamp subject))
 
       (advance-clock clock 10)
       (dvv:incf-dot subject)
 
-      (assert-equal 3 (dvv:dot-counter subject))
-      (assert-equal 20 (dvv:dot-timestamp subject)))))
+      (is = 3 (dvv:dot-counter subject))
+      (is = 20 (dvv:dot-timestamp subject)))))
 
-(define-test descendsp-empty-clock ()
+(define-test descendsp-empty-clock :parent dvv-suite
   (let ((empty (dvv:make-dotted-version-vector))
         (c1 (dvv:make-dotted-version-vector
              :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1))))
         (c2 (dvv:make-dotted-version-vector
              :initial-dot (dvv:make-dot +vnode-1+ :counter 2 :timestamp 2))))
 
-    (assert-true (dvv:descendsp c1 empty))
-    (assert-true (dvv:descendsp c2 empty))))
+    (true (dvv:descendsp c1 empty))
+    (true (dvv:descendsp c2 empty))))
 
-(define-test descendsp-self ()
+(define-test descendsp-self
+    :parent dvv-suite
   (let ((c1 (dvv:make-dotted-version-vector
              :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1))))
         (c2 (dvv:make-dotted-version-vector
              :initial-dot (dvv:make-dot +vnode-1+ :counter 2 :timestamp 2))))
-    (assert-true (dvv:descendsp c1 c1))
-    (assert-true (dvv:descendsp c2 c2))))
+    (true (dvv:descendsp c1 c1))
+    (true (dvv:descendsp c2 c2))))
 
-(define-test descendsp ()
+(define-test descendsp
+    :parent dvv-suite
   (let ((c1 (dvv:make-dotted-version-vector)))
     (dvv:incf-actor c1 +vnode-1+)
     (dvv:incf-actor c1 +vnode-3+)
     (let ((c2 (dvv:copy-dotted-version-vector c1)))
       (dvv:incf-actor c2 +vnode-2+) ; actor vnode-2 only exists in c2
       (dvv:incf-actor c2 +vnode-1+)
-      (assert-true (dvv:descendsp c2 c1)))))
+      (true (dvv:descendsp c2 c1)))))
 
-(define-test merge-works ()
+(define-test merge-works
+    :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector
               :initial-history (list
                                 (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)
@@ -87,55 +91,58 @@
                                 (dvv:make-dot +vnode-3+ :counter 3 :timestamp 3)
                                 (dvv:make-dot +vnode-4+ :counter 3 :timestamp 3)))))
 
-    (assert-true (dvv:emptyp (dvv:merge* (dvv:make-dotted-version-vector))) "Fresh dvv merges to empty dvv")
+    (true (dvv:emptyp (dvv:merge* (dvv:make-dotted-version-vector))) "Fresh dvv merges to empty dvv")
 
     (let ((c1-merged-with-c2 (dvv:merge* c1 c2)))
-      (assert-true (null (dvv:dotted-version-vector-dot c1-merged-with-c2)))
+      (true (null (dvv:dotted-version-vector-dot c1-merged-with-c2)))
 
       (let ((history (mapcar #'prelude:to-plist
                              (dvv:dotted-version-vector-history-sorted c1-merged-with-c2))))
-        (assert-equal
-         `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
-           (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
-           (:actor-id ,+vnode-3+ :counter 3 :timestamp 3)
-           ;; event 3 3 is removed for vnode-4
-           (:actor-id ,+vnode-4+ :counter 4 :timestamp 4))
-         history)))))
+        (is equal
+            `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
+              (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
+              (:actor-id ,+vnode-3+ :counter 3 :timestamp 3)
+              ;; event 3 3 is removed for vnode-4
+              (:actor-id ,+vnode-4+ :counter 4 :timestamp 4))
+            history)))))
 
-(define-test merge-less-left ()
+(define-test merge-less-left
+    :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-dot (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)))
          (c2 (dvv:make-dotted-version-vector :initial-history
                                              (list (dvv:make-dot +vnode-2+ :counter 2 :timestamp 2))
                                              :initial-dot (dvv:make-dot +vnode-3+ :counter 3 :timestamp 3)))
          (c1+c2 (dvv:merge* c1 c2)))
-    (assert-true (null (dvv:dotted-version-vector-dot c1+c2)))
-    (assert-equal
-     `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
-       (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
-       (:actor-id ,+vnode-3+ :counter 3 :timestamp 3))
-     (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
+    (true (null (dvv:dotted-version-vector-dot c1+c2)))
+    (is equal
+        `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
+          (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
+          (:actor-id ,+vnode-3+ :counter 3 :timestamp 3))
+        (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
 
-(define-test merge-less-right ()
+(define-test merge-less-right
+    :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-2+ :counter 2 :timestamp 2))
                                              :initial-dot (dvv:make-dot +vnode-3+ :counter 3 :timestamp 3)))
          (c2 (dvv:make-dotted-version-vector :initial-dot (dvv:make-dot +vnode-1+ :counter 1 :timestamp 1)))
          (c1+c2 (dvv:merge* c1 c2)))
-    (assert-true (null (dvv:dotted-version-vector-dot c1+c2)))
-    (assert-equal
-     `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
-       (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
-       (:actor-id ,+vnode-3+ :counter 3 :timestamp 3))
-     (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
+    (true (null (dvv:dotted-version-vector-dot c1+c2)))
+    (is equal
+        `((:actor-id ,+vnode-1+ :counter 1 :timestamp 1)
+          (:actor-id ,+vnode-2+ :counter 2 :timestamp 2)
+          (:actor-id ,+vnode-3+ :counter 3 :timestamp 3))
+        (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
 
-(define-test merge-same-id ()
+(define-test merge-same-id
+    :parent dvv-suite
   (let* ((c1 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 2))
                                              :initial-dot (dvv:make-dot +vnode-2+ :counter 1 :timestamp 4)))
          (c2 (dvv:make-dotted-version-vector :initial-history (list (dvv:make-dot +vnode-1+ :counter 1 :timestamp 3))
                                              :initial-dot (dvv:make-dot +vnode-3+ :counter 1 :timestamp 5)))
          (c1+c2 (dvv:merge* c1 c2)))
-    (assert-true (null (dvv:dotted-version-vector-dot c1+c2)))
-    (assert-equal
-     `((:actor-id ,+vnode-1+ :counter 1 :timestamp 3)
-       (:actor-id ,+vnode-2+ :counter 1 :timestamp 4)
-       (:actor-id ,+vnode-3+ :counter 1 :timestamp 5))
-     (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))
+    (true (null (dvv:dotted-version-vector-dot c1+c2)))
+    (is equal
+        `((:actor-id ,+vnode-1+ :counter 1 :timestamp 3)
+          (:actor-id ,+vnode-2+ :counter 1 :timestamp 4)
+          (:actor-id ,+vnode-3+ :counter 1 :timestamp 5))
+        (mapcar #'prelude:to-plist (dvv:dotted-version-vector-history-sorted c1+c2)))))

--- a/test/riacl.server/cluster/identifier.lisp
+++ b/test/riacl.server/cluster/identifier.lisp
@@ -1,38 +1,40 @@
-(in-package :riacl.server.tests.cluster)
+(in-package :riacl.server.tests)
+
+(define-test identifier-tests)
 
 (defmacro assert-identifier-implementation (identifier equal-identifier different-identifier)
   "Baseline tests for an identifier implementation. The implementation must provide "
   `(progn
-     (assert-true (identifier:identifierp ,identifier))
-     (assert-true (identifier:identifier= ,identifier ,identifier))
-     (assert-true (identifier:identifier= ,identifier ,equal-identifier))
-     (assert-true (not (identifier:identifier= ,identifier ,different-identifier)))
-     (assert-true (keywordp (identifier:kind-of ,identifier)))
-     (assert-no-signal 'error (identifier:identifier-sxhash ,identifier))))
+     (true (identifier:identifierp ,identifier))
+     (true (identifier:identifier= ,identifier ,identifier))
+     (true (identifier:identifier= ,identifier ,equal-identifier))
+     (true (not (identifier:identifier= ,identifier ,different-identifier)))
+     (true (keywordp (identifier:kind-of ,identifier)))
+     (true (identifier:identifier-sxhash ,identifier))))
 
-(define-test cluster-name-implements-identifier-interfaces ()
+(define-test cluster-name-implements-identifier-interfaces :parent identifier-tests
   (assert-identifier-implementation (identifier:cluster-name "test-cluster")
                                     (identifier:cluster-name "test-cluster")
                                     (identifier:cluster-name "test-cluster2")))
 
-(define-test node-name-implements-identifier-interfaces ()
+(define-test node-name-implements-identifier-interfaces :parent identifier-tests
   (assert-identifier-implementation (identifier:node-name 2130706433 "foo")
                                     (identifier:node-name 2130706433 "foo")
                                     (identifier:node-name 2130706433 "bar")))
 
-(define-test vnode-name-implements-identifier-interfaces ()
+(define-test vnode-name-implements-identifier-interfaces :parent identifier-tests
   (assert-identifier-implementation
    (identifier:vnode-name 2130706433 "foo" 1)
    (identifier:vnode-name 2130706433 "foo" 1)
    (identifier:vnode-name 2130706433 "bar" 1)))
 
-(define-test bucket-name-implements-identifier-interfaces ()
+(define-test bucket-name-implements-identifier-interfaces :parent identifier-tests
   (assert-identifier-implementation
    (identifier:bucket-name "pets" "dog")
    (identifier:bucket-name "pets" "dog")
    (identifier:bucket-name "plants" "tree")))
 
-(define-test object-key-implements-identifier-interfaces ()
+(define-test object-key-implements-identifier-interfaces :parent identifier-tests
   (assert-identifier-implementation
    (identifier:object-key "pets" "dog" "fido")
    (identifier:object-key "pets" "dog" "fido")

--- a/test/riacl.server/config/config.lisp
+++ b/test/riacl.server/config/config.lisp
@@ -1,7 +1,9 @@
-(in-package :riacl.server.tests.config)
+(in-package :riacl.server.tests)
 
-(define-test as-boolean-works ()
-  (assert-true (config::as-boolean "yes"))
-  (assert-true (config::as-boolean "1"))
-  (assert-true (config::as-boolean "true"))
-  (assert-false (config::as-boolean "false")))
+(define-test config-tests)
+
+(define-test as-boolean-works :parent config-tests
+  (true (config::as-boolean "yes"))
+  (true (config::as-boolean "1"))
+  (true (config::as-boolean "true"))
+  (false (config::as-boolean "false")))

--- a/test/riacl.server/package.lisp
+++ b/test/riacl.server/package.lisp
@@ -1,13 +1,6 @@
 (in-package :cl-user)
 
 (defpackage #:riacl.server.tests
-  (:use :cl :lisp-unit2)
+  (:use :cl :parachute)
+  (:local-nicknames (:a :alexandria) (:s :serapeum))
   (:export #:run-suites))
-
-(defpackage #:riacl.server.tests.cluster
-  (:use :cl :lisp-unit2)
-  (:local-nicknames (:a :alexandria) (:s :serapeum)))
-
-(defpackage #:riacl.server.tests.config
-  (:use :cl :lisp-unit2)
-  (:local-nicknames (:a :alexandria) (:s :serapeum)))

--- a/test/riacl.server/runner.lisp
+++ b/test/riacl.server/runner.lisp
@@ -1,18 +1,9 @@
 (in-package #:riacl.server.tests)
 
-(defmacro with-env-specific-setup (&body body)
-  (let ((db (gensym)))
-    `(if (uiop:getenvp "CI_ENV")
-         (let ((*debugger-hook*))
-           (let ((,db (with-summary () ,@body)))
-             (unless (and (null (lisp-unit2::failed-assertions ,db))
-                          (null (errors ,db)))
-               (uiop:quit 1))))
-         (with-summary () ,@body))))
-
 (defun run-suites ()
   (push :test *features*)
-  (with-env-specific-setup
-      (run-tests
-       :name "riacl.server.tests"
-       :package '(#:riacl.server.tests.cluster #:riacl.server.tests.config))))
+  (if (uiop:getenvp "CI_ENV")
+      (progn
+        (defvar cl-user::*exit-on-test-failures* t)
+        (parachute:test :riacl.server.tests :report 'plain))
+      (parachute:test :riacl.server.tests :report 'interactive)))


### PR DESCRIPTION
Replace lisp-unit2 with parachute, just because parachute is a tiny bit nicer